### PR TITLE
Add sys module so that pokecord can restart properly.

### DIFF
--- a/PokeCord.py
+++ b/PokeCord.py
@@ -2,6 +2,9 @@ from discord.ext import commands
 from Config import *
 from Objects.user import *
 
+# sys is needed for the restart function. See line 142.
+import sys
+
 from datetime import time, datetime, timedelta
 
 import requests


### PR DESCRIPTION
When I was initially testing this bot, I discovered that the restart command doesn't work because it's trying to call on functions in the 'sys' module even though it's not imported.

This imports the sys module.